### PR TITLE
Update PrintThisAsset.php

### DIFF
--- a/PrintThisAsset.php
+++ b/PrintThisAsset.php
@@ -5,7 +5,7 @@ use yii\web\AssetBundle;
 
 class PrintThisAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/printthis';
+    public $sourcePath = '@bower/printThis';
 
     public $js = [
         '//code.jquery.com/jquery-migrate-1.3.0.min.js',


### PR DESCRIPTION
Starting with version 1.0.1 I get next error: "The file or directory to be published does not exist: /home/xxx/www/rrr/vendor/bower/printthis" because bower set the name folder "printThis" not "printthis" and linux is case-sensitive. Please put back the "printThis"! Thanks!